### PR TITLE
Update wrapper.sage to let BaseGenerator have a .seed property.

### DIFF
--- a/dashboard/checkit/wrapper/wrapper.sage
+++ b/dashboard/checkit/wrapper/wrapper.sage
@@ -165,6 +165,10 @@ class BaseGenerator:
     def data(self):
         return {}
 
+    @property
+    def seed(self):
+        return self.__seed
+
     @provide_data
     def graphics(data):
         return None


### PR DESCRIPTION
Addresses Issue #81